### PR TITLE
Only patch PAL Wii games when using progressive

### DIFF
--- a/resources/wiiflow_game_booter/source/ChannelHandler.cpp
+++ b/resources/wiiflow_game_booter/source/ChannelHandler.cpp
@@ -150,12 +150,12 @@ u32 LoadChannel(u64 title, bool dol, u32 *IOS)
 	return entry;
 }
 
-void PatchChannel(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, u8 patchVidModes, int aspectRatio)
+void PatchChannel(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, u8 patchVidModes, int aspectRatio, u8 bootType)
 {
 	bool hookpatched = false;
 	for(u8 i = 0; i < dolchunkcount; i++)
 	{		
-		patchVideoModes(dolchunkoffset[i], dolchunksize[i], vidMode, vmode, patchVidModes);
+		patchVideoModes(dolchunkoffset[i], dolchunksize[i], vidMode, vmode, patchVidModes, bootType);
 		if(vipatch)
 			vidolpatcher(dolchunkoffset[i], dolchunksize[i]);
 		if(configbytes[0] != 0xCD)

--- a/resources/wiiflow_game_booter/source/ChannelHandler.hpp
+++ b/resources/wiiflow_game_booter/source/ChannelHandler.hpp
@@ -14,7 +14,7 @@ typedef struct _dolheader
 } ATTRIBUTE_PACKED dolheader;
 
 void PatchChannel(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, 
-					u8 patchVidModes, int aspectRatio);
+					u8 patchVidModes, int aspectRatio, u8 bootType);
 u32 LoadChannel(u64 title, bool dol, u32 *IOS);
 
 #endif /* __CHANHANDLE_HPP_ */

--- a/resources/wiiflow_game_booter/source/apploader.c
+++ b/resources/wiiflow_game_booter/source/apploader.c
@@ -29,7 +29,7 @@ static const char *GameID = (const char*)0x80000000;
 #define APPLDR_CODE		0x918
 
 void maindolpatches(void *dst, int len, u8 vidMode, GXRModeObj *vmode, bool vipatch, 
-				bool countryString, u8 patchVidModes, int aspectRatio, u32 returnTo, bool patchregion, bool private_server);
+				bool countryString, u8 patchVidModes, int aspectRatio, u32 returnTo, bool patchregion, bool private_server, u8 bootType);
 static void patch_NoDiscinDrive(void *buffer, u32 len);
 static void Anti_002_fix(void *Address, int Size);
 static bool Remove_001_Protection(void *Address, int Size);
@@ -49,7 +49,7 @@ static struct
 } apploader_hdr ATTRIBUTE_ALIGN(32);
 
 u32 Apploader_Run(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, u8 patchVidModes, int aspectRatio, u32 returnTo, 
-					bool patchregion , bool private_server, bool patchFix480p)
+					bool patchregion , bool private_server, bool patchFix480p, u8 bootType)
 {
 	PrinceOfPersiaPatch();
 	NewSuperMarioBrosPatch();
@@ -96,7 +96,7 @@ u32 Apploader_Run(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryStrin
 		/* Read data from DVD */
 		WDVD_Read(dst, len, offset);
 		maindolpatches(dst, len, vidMode, vmode, vipatch, countryString, 
-						patchVidModes, aspectRatio, returnTo, patchregion, private_server);
+						patchVidModes, aspectRatio, returnTo, patchregion, private_server, bootType);
 		DCFlushRange(dst, len);
 		ICInvalidateRange(dst, len);
 		prog(20);
@@ -114,7 +114,7 @@ u32 Apploader_Run(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryStrin
 	return (u32)appldr_final();
 }
 
-void maindolpatches(void *dst, int len, u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, u8 patchVidModes, int aspectRatio, u32 returnTo, bool patchregion , bool private_server)
+void maindolpatches(void *dst, int len, u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, u8 patchVidModes, int aspectRatio, u32 returnTo, bool patchregion , bool private_server, u8 bootType)
 {
 	do_wip_code((u8 *)dst, len);
 	Remove_001_Protection(dst, len);
@@ -122,7 +122,7 @@ void maindolpatches(void *dst, int len, u8 vidMode, GXRModeObj *vmode, bool vipa
 		Anti_002_fix(dst, len);
 	if((CurrentIOS.Type == IOS_TYPE_WANIN && CurrentIOS.Revision < 13) || CurrentIOS.Type == IOS_TYPE_HERMES)
 		patch_NoDiscinDrive(dst, len);
-	patchVideoModes(dst, len, vidMode, vmode, patchVidModes);
+	patchVideoModes(dst, len, vidMode, vmode, patchVidModes, bootType);
 
 	if(debuggerselect == 2)
 		Patch_fwrite(dst, len);

--- a/resources/wiiflow_game_booter/source/apploader.h
+++ b/resources/wiiflow_game_booter/source/apploader.h
@@ -7,7 +7,7 @@ extern "C" {
 
 /* Prototypes */
 u32 Apploader_Run(u8 vidMode, GXRModeObj *vmode, bool vipatch, bool countryString, u8 patchVidModes, int aspectRatio, u32 returnTo, 
-					bool patchregion, bool private_server, bool patchFix480p);
+					bool patchregion, bool private_server, bool patchFix480p, u8 bootType);
 
 #ifdef __cplusplus
 }

--- a/resources/wiiflow_game_booter/source/main.cpp
+++ b/resources/wiiflow_game_booter/source/main.cpp
@@ -108,7 +108,7 @@ int main()
 			normalCFG.patchVidMode = 1; //progressive mode requires this
 		vmode = Disc_SelectVMode(normalCFG.vidMode, &vmode_reg);
 		AppEntrypoint = Apploader_Run(normalCFG.vidMode, vmode, normalCFG.vipatch, normalCFG.countryString, normalCFG.patchVidMode, normalCFG.aspectRatio, 
-						normalCFG.returnTo, normalCFG.patchregion, normalCFG.private_server, normalCFG.patchFix480p);
+						normalCFG.returnTo, normalCFG.patchregion, normalCFG.private_server, normalCFG.patchFix480p, normalCFG.BootType);
 		WDVD_Close();
 	}
 	else if(normalCFG.BootType == TYPE_CHANNEL)
@@ -118,7 +118,7 @@ int main()
 		vmode = Disc_SelectVMode(normalCFG.vidMode, &vmode_reg);
 		AppEntrypoint = LoadChannel(normalCFG.title, normalCFG.use_dol, &GameIOS);
 		PatchChannel(normalCFG.vidMode, vmode, normalCFG.vipatch, normalCFG.countryString, 
-					normalCFG.patchVidMode, normalCFG.aspectRatio);
+					normalCFG.patchVidMode, normalCFG.aspectRatio, normalCFG.BootType);
 		ISFS_Deinitialize();
 	}
 	gprintf("Entrypoint: %08x, Requested Game IOS: %i\n", AppEntrypoint, GameIOS);

--- a/resources/wiiflow_game_booter/source/videopatch.c
+++ b/resources/wiiflow_game_booter/source/videopatch.c
@@ -3,6 +3,7 @@
 #include "videopatch.h"
 
 #include <string.h>
+#include <types.h>
 
 #define ARRAY_SIZE(a)	(sizeof a / sizeof a[0])
 
@@ -265,12 +266,13 @@ static bool Search_and_patch_Video_Modes(void *Address, u32 Size, GXRModeObj* Ta
 	return found;
 }
 
-void patchVideoModes(void *dst, u32 len, int vidMode, GXRModeObj *vmode, int patchVidModes)
+void patchVideoModes(void *dst, u32 len, int vidMode, GXRModeObj *vmode, int patchVidModes, u8 bootType)
 {
 	GXRModeObj **table = 0;
+	char region = *((char *)(0x80000003));
 
-	// Video patch set to "all" or the video mode is progressive
-	if((patchVidModes == 3 || vidMode == 5) && vmode != 0)
+	// Video patch set to "all" or the video mode is progressive and it's a PAL Wii game
+	if((patchVidModes == 3 || (vidMode == 5 && region == 'P' && bootType == TYPE_WII_GAME)) && vmode != 0)
 		applyVideoPatch(dst, len, vmode, true);
 	// Video patch set to "more"
 	else if(patchVidModes == 2 && vmode != 0)

--- a/resources/wiiflow_game_booter/source/videopatch.h
+++ b/resources/wiiflow_game_booter/source/videopatch.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-void patchVideoModes(void *dst, u32 len, int vidMode, GXRModeObj *vmode, int patchVidModes); 
+void patchVideoModes(void *dst, u32 len, int vidMode, GXRModeObj *vmode, int patchVidModes, u8 bootType); 
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
With WiiFlow Lite v5.4.4 all games were being patched if you used the progressive video mode. This caused issues for WiiWare games, so now we should only patch PAL Wii games.