### PR TITLE
Use RiiConnect24 geckocodes archive

### DIFF
--- a/source/menu/menu_cheat.cpp
+++ b/source/menu/menu_cheat.cpp
@@ -4,8 +4,7 @@
 #include "lockMutex.hpp"
 #include "network/https.h"
 
-//#define GECKOURL "http://geckocodes.org/codes/%c/%s.txt"
-#define GECKOURL "https://www.geckocodes.org/txt.php?txt=%s"
+#define GECKOURL "https://codes.rc24.xyz/txt.php?txt=%s"
 #define CHEATSPERPAGE 4
 
 u8 m_cheatSettingsPage = 0;

--- a/source/network/https.c
+++ b/source/network/https.c
@@ -471,19 +471,15 @@ void downloadfile(const char *url, struct download *buffer)
 	}
 	// Send our request
 	char request[2300];
-	char isgecko[36] = "Cookie: challenge=BitMitigate.com\r\n";
 	int ret, len;
-	if (strncmp(host, "www.geckocodes.org", 18) != 0)
-		memset(isgecko, 0, sizeof(isgecko)); // Not geckocodes, so don't set a cookie
 	len = snprintf(request, sizeof(request),
 				   "GET %s HTTP/1.1\r\n"
 				   "Host: %s\r\n"
 				   "User-Agent: WiiFlow-Lite\r\n"
 				   "Connection: close\r\n"
-				   "%s"
 				   "Pragma: no-cache\r\n"
 				   "Cache-Control: no-cache\r\n\r\n",
-				   path, host, isgecko);
+				   path, host);
 	if ((ret = https_write(&httpinfo, request, len, false)) != len)
 	{
 #ifdef DEBUG_NETWORK


### PR DESCRIPTION
[GeckoCodes](https://geckocodes.org/) has recently shutdown, this uses RiiConnect24's archive instead of trying to download ocarina codes from there. Also removed the cookie stuff, codes.rc24.xyz isn't proxied by CF or the likes. Tested and working.