### PR TITLE
Add Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,73 @@
+name: Build binaries
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        id: cache-1
+        uses: actions/cache@v2
+        with:
+          path: cache
+          key: ${{ runner.os }}-cache-1
+
+      - name: Download devkitPPC r30, libogc 1.8.19, bin2s and elf2dol
+        if: steps.cache-1.outputs.cache-hit != 'true'
+        # general-tools is needed for bin2s and gamecube-tools is needed for elf2dol
+        run: | 
+          mkdir cache && cd cache
+          wget "https://wii.leseratte10.de/devkitPro/file.php/devkitPPC-r30-1-linux.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/libogc-1.8.19-1-any.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/general-tools-1.2.0-1-linux.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/gamecube-tools-1.0.2-1-linux.pkg.tar.xz"
+          cd ..
+
+      - name: Extract devkitPPC r30, libogc 1.8.19, bin2s and elf2dol
+        # general-tools is needed for bin2s and gamecube-tools is needed for elf2dol
+        run: | 
+          tar -xf cache/devkitPPC-r30-1-linux.pkg.tar.xz opt/devkitpro/devkitPPC --strip-components=1
+          tar -xf cache/libogc-1.8.19-1-any.pkg.tar.xz opt/devkitpro/libogc --strip-components=1
+          tar -xf cache/general-tools-1.2.0-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/bin2s --strip-components=4
+          sudo cp bin2s /usr/local/bin/bin2s
+          tar -xf cache/gamecube-tools-1.0.2-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/elf2dol --strip-components=4
+          sudo cp elf2dol /usr/local/bin/elf2dol
+
+      - name: Patch libogc
+        run: |
+          if [[ "$(xxd -s 608918 -g4 -l4 $(pwd)/devkitpro/libogc/lib/wii/libogc.a | cut -d\  -f2)" == "38800001" ]]; then
+            echo "Found correct value at offset 608918 (0x94a96) -> patching libogc ..."
+            printf '\x38\x80\x00\x03' | dd of=$(pwd)/devkitpro/libogc/lib/wii/libogc.a bs=1 seek=608918 count=4 conv=notrunc
+            if [[ "$(xxd -s 608918 -g4 -l4 $(pwd)/devkitpro/libogc/lib/wii/libogc.a | cut -d\  -f2)" == "38800003" ]]; then
+              echo "Patch successful"
+            else
+              echo "Patch failed!!"
+              /bin/false
+            fi
+          else
+            echo "Fail: $(xxd -s 608918 -g4 -l4 $(pwd)/devkitpro/libogc/lib/wii/libogc.a | cut -d\  -f2)"
+          fi
+      - name: Compile
+        run: |
+          PATH=$(pwd)/devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/devkitpro/devkitPPC DEVKITPRO=$(pwd)/devkitpro make
+      - name: Package
+        run: |
+          cp -r wii/apps apps
+          mkdir -p apps/wiiflow/
+          cp -r out/bins apps/wiiflow/bins
+          cp -r out/imgs apps/wiiflow/imgs
+          cp out/boot.dol apps/wiiflow/
+          mkdir -p wiiflow
+          cp -r wii/wiiflow/Languages wiiflow/languages
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v2
+        with: 
+          name: wiiflow_lite
+          path: |
+            apps
+            wiiflow

--- a/Makefile.main
+++ b/Makefile.main
@@ -57,6 +57,12 @@ CFLAGS		=	-g -ggdb -O2 -Wall -Wno-multichar -Wextra $(MACHDEP) $(INCLUDE) -D_GNU
 CXXFLAGS	=	$(CFLAGS)
 LDFLAGS		=	-g -ggdb $(MACHDEP) -Wl,-Map,$(notdir $@).map,--section-start,.init=0x80620000,-wrap,malloc,-wrap,free,-wrap,memalign,-wrap,calloc,-wrap,realloc,-wrap,malloc_usable_size,-wrap,wiiuse_register
 
+ifeq ($(GITHUB_ACTIONS),true)
+SHA = $(GITHUB_SHA)
+CFLAGS += -DCOMMITHASH='"$(shell echo "$(SHA)" | cut -c 1-8)"'
+CXXFLAGS += -DCOMMITHASH='"$(shell echo "$(SHA)" | cut -c 1-8)"'
+endif
+
 ifeq ($(BUILDMODE),channel)
 CFLAGS += -DFULLCHANNEL
 CXXFLAGS += -DFULLCHANNEL

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -86,7 +86,11 @@ int main(int argc, char **argv)
 	mainIOS = DOL_MAIN_IOS;// 249
 	__exception_setreload(10);
 	Gecko_Init(); //USB Gecko and SD/WiFi buffer
-	gprintf(" \nWelcome to %s %s!\nThis is the debug output.\n", APP_NAME, APP_VERSION);
+	#ifdef COMMITHASH
+		gprintf(" \nWelcome to %s %s %s!\nThis is the debug output.\n", APP_NAME, APP_VERSION, COMMITHASH);
+	#else
+		gprintf(" \nWelcome to %s %s!\nThis is the debug output.\n", APP_NAME, APP_VERSION);
+	#endif
 
 	bool iosOK = true;
 	char *gameid = NULL;

--- a/source/menu/menu_about.cpp
+++ b/source/menu/menu_about.cpp
@@ -145,7 +145,11 @@ void CMenu::_textAbout(void)
 		return; 
 	}
 	// show credits and current cIOS
-	m_btnMgr.setText(m_aboutLblTitle, wfmt(L"%s %s", APP_NAME, APP_VERSION));
+	#ifdef COMMITHASH
+		m_btnMgr.setText(m_aboutLblTitle, wfmt(L"%s %s %s", APP_NAME, APP_VERSION, COMMITHASH));
+	#else
+		m_btnMgr.setText(m_aboutLblTitle, wfmt(L"%s %s", APP_NAME, APP_VERSION));
+	#endif
 
 	wstringEx developers(wfmt(_fmt("about6", L"Current Developers:\n%s"), DEVELOPERS));
 	wstringEx pDevelopers(wfmt(_fmt("about7", L"Past Developers:\n%s"), PAST_DEVELOPERS));

--- a/source/menu/menu_home.cpp
+++ b/source/menu/menu_home.cpp
@@ -432,7 +432,11 @@ void CMenu::_initHomeAndExitToMenu()
 
 void CMenu::_textHome(void)
 {
+	#ifdef COMMITHASH
+	m_btnMgr.setText(m_homeLblTitle, wfmt(L"%s %s %s", APP_NAME, APP_VERSION, COMMITHASH));
+	#else
 	m_btnMgr.setText(m_homeLblTitle, wfmt(L"%s %s", APP_NAME, APP_VERSION));
+	#endif
 	m_btnMgr.setText(m_homeBtnHelp, _t("about10", L"Help Guide"));
 	m_btnMgr.setText(m_homeBtnReloadCache, _t("home2", L"Reload Cache"));
 	m_btnMgr.setText(m_homeBtnExplorer, _t("home8", L"File Explorer"));


### PR DESCRIPTION
This pull request adds a github action config file that enables CI for this repository. What that means is with every commit made to the repo, Github will automatically spin up a Linux container, compile WiiFlow Lite in exactly that version that has been commited, and then provides a download link to that version. 

Just thought that could be helpful, 1. it confirms that every commit can be built successfully and/or displays if that's not the case, 2. it kinda documents which exact steps are necessary to compile WiiFlow Lite, and 3. it also runs on incoming pull requests (I believe, I was unable to test that yet) so you can see if merging a PR would break stuff. And 4., if you put the needed archives (devkitPPC, libogc, general-tools, gamecube-tools) that are currently loaded from my server into a github release and load them from there, that guarantees that this repository will contain everything that's needed to build WiiFlow Lite, to archive all that for the future.

Currently this CI config will download the needed binaries (devkitPPC r30, libogc 1.8.19, bin2s, elf2dol) from my devkitPro archive at wii.leseratte10.de. If you don't like that and would like to have a setup that doesn't require my server to exist / be online, you could also download the four binaries manually, upload them somewhere else (for example, as a github release in this repo) and modify the URLs in the main.yml file. 

EDIT: This is how this CI would look then: https://github.com/Leseratte10/WiiFlow_Lite/runs/1397315620 
And here's an example on how archiving devkitPPC and stuff on github as well - by just making a dummy release and adding the four needed archives referenced in this PR: https://github.com/Leseratte10/compile-devkitARM-r32/releases/tag/helpers 