### PR TITLE
custom_titles.ini allowing to group same aliases for several plugins.

### DIFF
--- a/source/config/config.cpp
+++ b/source/config/config.cpp
@@ -1,5 +1,6 @@
 
 #include <fstream>
+#include <sstream>
 
 #include "config.hpp"
 #include "gecko/gecko.hpp"
@@ -196,6 +197,7 @@ void Config::unload(void)
 	m_changed = false;
 	m_filename = emptyString;
 	m_domains.clear();
+	m_groupCustomTitles.clear();
 }
 
 void Config::save(bool unload)
@@ -223,6 +225,18 @@ bool Config::has(const std::string &domain, const std::string &key) const
 	DomainMap::const_iterator i = m_domains.find(upperCase(domain));
 	if (i == m_domains.end()) return false;
 	return i->second.find(lowerCase(key)) != i->second.end();
+}
+
+void Config::groupCustomTitles(void)
+{
+	for (Config::DomainMap::iterator k = m_domains.begin(); k != m_domains.end(); ++k)
+	{
+		string uc_domain(upperCase(k->first));
+		istringstream f(uc_domain);
+		string s;
+		while (getline(f, s, ','))
+			m_groupCustomTitles[s] = uc_domain;
+	}
 }
 
 void Config::setWString(const string &domain, const string &key, const wstringEx &val)
@@ -336,6 +350,22 @@ string Config::getString(const string &domain, const string &key, const string &
 	if(domain.empty() || key.empty())
 		return defVal;
 	string &data = m_domains[upperCase(domain)][lowerCase(key)];
+	if(data.empty())
+	{
+		data = defVal;
+		//gprintf("setString %s\n", defVal.c_str());
+		m_changed = true;
+	}
+	return data;
+}
+
+string Config::getStringCustomTitles(const string &domain, const string &key, const string &defVal)
+{
+	if(domain.empty() || key.empty())
+		return defVal;
+	KeyMap::iterator i = m_groupCustomTitles.find(upperCase(domain));
+	if (i == m_groupCustomTitles.end()) return defVal;
+	string &data = m_domains[i->second][lowerCase(key)];
 	if(data.empty())
 	{
 		data = defVal;

--- a/source/config/config.hpp
+++ b/source/config/config.hpp
@@ -13,8 +13,9 @@ class Config
 {
 public:
 	Config(void);
-	void clear(void) { m_domains.clear(); }
+	void clear(void) { m_domains.clear(); m_groupCustomTitles.clear();}
 	bool load(const char *filename = 0);
+	void groupCustomTitles(void);
 	void unload(void);
 	void save(bool unload = false);
 	bool loaded(void) const { return m_loaded; }
@@ -32,6 +33,7 @@ public:
 	// Get
 	wstringEx getWString(const std::string &domain, const std::string &key, const wstringEx &defVal = wstringEx());
 	std::string getString(const std::string &domain, const std::string &key, const std::string &defVal = std::string());
+	std::string getStringCustomTitles(const std::string &domain, const std::string &key, const std::string &defVal = std::string());
 	vector<std::string> getStrings(const std::string &domain, const std::string &key, char seperator = ',', const std::string &defval = std::string());
 	bool getBool(const std::string &domain, const std::string &key, bool defVal = false);
 	int getOptBool(const std::string &domain, const std::string &key, int defVal = 2);
@@ -60,6 +62,7 @@ private:
 	DomainMap m_domains;
 	std::string m_filename;
 	DomainMap::iterator m_iter;
+	KeyMap m_groupCustomTitles;
 	static const std::string emptyString;
 private:
 	Config(const Config &);

--- a/source/list/ListGenerator.cpp
+++ b/source/list/ListGenerator.cpp
@@ -56,6 +56,7 @@ void ListGenerator::OpenConfigs()
 	if(gameTDB.IsLoaded())
 		gameTDB.SetLanguageCode(gameTDB_Language.c_str());
 	CustomTitles.load(CustomTitlesPath.c_str());
+	CustomTitles.groupCustomTitles();
 }
 
 void ListGenerator::CloseConfigs()
@@ -275,7 +276,7 @@ static void Add_Plugin_Game(char *FullPath)
 	const char *RomFilename = strrchr(FullPath, '/') + 1;
 	*strrchr(RomFilename, '.') = '\0';
 	
-	string customTitle = CustomTitles.getString(m_plugin.PluginMagicWord, RomFilename, "");
+	string customTitle = CustomTitles.getStringCustomTitles(m_plugin.PluginMagicWord, RomFilename, "");
 	
 	const char *gameTDB_Title = NULL;
 	if(gameTDB.IsLoaded() && customTitle.empty() && m_cacheList.usePluginDBTitles)
@@ -410,6 +411,7 @@ void ListGenerator::CreateRomList(Config &platform_cfg, const string& romsDir, c
 		}
 	}
 	CustomTitles.load(CustomTitlesPath.c_str());
+	CustomTitles.groupCustomTitles();
 	GetFiles(romsDir.c_str(), FileTypes, Add_Plugin_Game, false, 30);//wow 30 subfolders! really?
 	CloseConfigs();
 	romNamesDB.unload();


### PR DESCRIPTION
This PR allows to have wiiflow\settings\custom_titles.ini referring to the same titles for a set of plugins (usually various emulators for the same platform). For plugins using the same set of roms (eventually large number of roms), this avoid to duplicate the same lines for each plugin.

Syntax to use in custom_titles.ini:
[MAGICNUMBER1,MAGICNUMBER2,...]
rom1=Name 1
rom2=Name 2
...