### PR TITLE
Accept any file ending for filetypes

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -55,7 +55,7 @@ ios			:=	249
 #---------------------------------------------------------------------------------
 FALSE_POSITIVES := -Wno-array-bounds -Wno-stringop-overflow -Wno-stringop-overread
 CFLAGS		=	-g -ggdb -O2 -Wall -Wno-multichar -Wno-address-of-packed-member -Wextra $(FALSE_POSITIVES) $(MACHDEP) $(INCLUDE) -D_GNU_SOURCE -DHAVE_CONFIG_H
-CXXFLAGS	=	$(CFLAGS)
+CXXFLAGS	=	$(CFLAGS) -std=c++20
 LDFLAGS		=	-g -ggdb $(MACHDEP) -Wl,-Map,$(notdir $@).map,--section-start,.init=0x80620000,-wrap,malloc,-wrap,free,-wrap,memalign,-wrap,calloc,-wrap,realloc,-wrap,malloc_usable_size,-wrap,wiiuse_register
 
 ifeq ($(GITHUB_ACTIONS),true)

--- a/source/list/ListGenerator.cpp
+++ b/source/list/ListGenerator.cpp
@@ -253,7 +253,7 @@ static void Add_Plugin_Game(char *FullPath)
 {
 	/* Get roms's title without the extra ()'s or []'s */
 	string ShortName = m_plugin.GetRomName(FullPath);
-	//gprintf("shortName=%s\n", ShortName.c_str());
+	//gprintf("fullName=%s, shortName=%s\n", FullPath, ShortName.c_str());
 
 	/* only add disc 1 of multi disc games */
 	const char *RomFilename = strrchr(FullPath, '/') + 1;
@@ -466,9 +466,11 @@ void ListGenerator::CreateList(u32 Flow, const string& Path, const vector<string
 
 static inline bool IsFileSupported(const char *File, const vector<string>& FileTypes)
 {
-	for(vector<string>::const_iterator cmp = FileTypes.begin(); cmp != FileTypes.end(); ++cmp)
+	auto fileName = std::string(File);
+	for (auto & fileType : FileTypes)
 	{
-		if(strcasecmp(File, cmp->c_str()) == 0)
+		if (fileName.length() >= fileType.length() &&
+		    fileName.ends_with(fileType))
 			return true;
 	}
 	return false;
@@ -503,9 +505,7 @@ void GetFiles(const char *Path, const vector<string>& FileTypes,
 		}
 		else if(pent->d_type == DT_REG)
 		{
-			NewFileName = strrchr(pent->d_name, '.');//the extension
-			if(NewFileName == NULL) NewFileName = pent->d_name;
-			if(IsFileSupported(NewFileName, FileTypes))
+			if(IsFileSupported(pent->d_name, FileTypes))
 			{
 				AddFile(FullPathChar);
 				continue;

--- a/source/list/ListGenerator.cpp
+++ b/source/list/ListGenerator.cpp
@@ -470,7 +470,14 @@ static inline bool IsFileSupported(const char *File, const vector<string>& FileT
 	for (auto & fileType : FileTypes)
 	{
 		if (fileName.length() >= fileType.length() &&
-		    fileName.ends_with(fileType))
+		    std::equal(fileName.end() - fileType.length(),
+                               fileName.end(), fileType.begin(),
+			       [](const char & c1, const char & c2)
+			       {
+					return (c1 == c2 ||
+						std::toupper(c1) ==
+						std::toupper(c2));
+			       }))
 			return true;
 	}
 	return false;


### PR DESCRIPTION
With this change WiiFlow accepts any string in `filetypes` as a file type. The file extension no longer has to contain a dot (and not more). Any text is allowed.

If you do not change your configuration of `filetypes`, you will not notice any change in behaviour. However, those who make use of this can solve the problem from #274 as follows.

Let's imagine we have PS1 games that are typically named like this:
```
Tales of Destiny II (USA) (Disc 1).cue
Tales of Destiny II (USA) (Disc 1) (Track 1).bin
Tales of Destiny II (USA) (Disc 1) (Track 2).bin
Tales of Destiny II (USA) (Disc 2).cue
Tales of Destiny II (USA) (Disc 2) (Track 1).bin
Tales of Destiny II (USA) (Disc 2) (Track 2).bin
Tales of Destiny II (USA) (Disc 3).cue
Tales of Destiny II (USA) (Disc 3) (Track 1).bin
Tales of Destiny II (USA) (Disc 3) (Track 2).bin
```

Then you would write either `(Disc 1) (Track 1).bin` in `filetypes` to select exactly the first `bin` of the first disc,
or `(Disc 1).cue` to select the `cue`. For games that do not consist of multiple tracks per disc, you would write `(Disc 1).bin` in `filetype`. Combined, this gives `filetypes=(Disc 1) (Track 1).bin|(Disc 1).bin`.

The downside of the solution is that single-disc games must also follow the naming scheme.

Never mind, you don't have to use it. With the change, everything works as before, without changes to the configuration.

