### PR TITLE
Support for exclusion of certain multi disc/tape files

### DIFF
--- a/source/list/ListGenerator.hpp
+++ b/source/list/ListGenerator.hpp
@@ -29,11 +29,15 @@
 #include "gui/GameTDB.hpp"
 #include "plugin/plugin.hpp"
 
+#define CONFIG_FILENAME_SKIP_DOMAIN	"PLUGINS"
+#define CONFIG_FILENAME_SKIP_KEY	"filename_skip_regex"
+#define CONFIG_FILENAME_SKIP_DEFAULT	"((dis[ck]|tape|side|track)[ _-]?[b-z2-9])"
+
 class ListGenerator : public std::vector<dir_discHdr>
 {
 public:
 	void createSFList(u8 maxBtns, Config &m_sourceMenuCfg, const string& sourceDir);
-	void Init(const char *settingsDir, const char *Language, const char *plgnsDataDir);
+	void Init(const char *settingsDir, const char *Language, const char *plgnsDataDir, const std::string& fileNameSkipPattern);
 	void Clear();
 	void ParseScummvmINI(Config &ini, const char *Device, const char *datadir, const char *platform, const string& DBName, bool UpdateCache);
 	void CreateRomList(Config &platform_cfg, const string& romsDir, const vector<string>& FileTypes, const string& DBName, bool UpdateCache);

--- a/source/menu/menu.cpp
+++ b/source/menu/menu.cpp
@@ -407,7 +407,8 @@ bool CMenu::init(bool usb_mounted)
 	}
 
 	/* Init gametdb and custom titles for game list making */
-	m_cacheList.Init(m_settingsDir.c_str(), m_loc.getString(m_curLanguage, "gametdb_code", "EN").c_str(), m_pluginDataDir.c_str());
+	m_cacheList.Init(m_settingsDir.c_str(), m_loc.getString(m_curLanguage, "gametdb_code", "EN").c_str(), m_pluginDataDir.c_str(),
+			 m_cfg.getString(CONFIG_FILENAME_SKIP_DOMAIN,CONFIG_FILENAME_SKIP_KEY,CONFIG_FILENAME_SKIP_DEFAULT));
 
 	/* Init the onscreen pointer */
 	m_aa = 3;

--- a/source/menu/menu_config_adv.cpp
+++ b/source/menu/menu_config_adv.cpp
@@ -174,7 +174,8 @@ int CMenu::_configAdv(void)
 	_hideConfigAdv();
 	if(m_curLanguage != prevLanguage)
 	{
-		m_cacheList.Init(m_settingsDir.c_str(), m_loc.getString(m_curLanguage, "gametdb_code", "EN").c_str(), m_pluginDataDir.c_str());
+		m_cacheList.Init(m_settingsDir.c_str(), m_loc.getString(m_curLanguage, "gametdb_code", "EN").c_str(), m_pluginDataDir.c_str(),
+				 m_cfg.getString(CONFIG_FILENAME_SKIP_DOMAIN,CONFIG_FILENAME_SKIP_KEY,CONFIG_FILENAME_SKIP_DEFAULT));
 		fsop_deleteFolder(m_listCacheDir.c_str());// delete cache lists folder and remake it so all lists update.
 		fsop_MakeFolder(m_listCacheDir.c_str());
 		m_refreshGameList = true;


### PR DESCRIPTION
With the new setting `filename_skip_regex` in the section `PLUGINS`, which contains a regular expression, files can be excluded from the games list again. A typical use case is the exclusion of all disks except the first one in multi-disk games.

The default, compiled in pattern, is `filename_skip_regex=((dis[ck]|tape|side|track)[ _-]?[b-z2-9])`.

I have decided to allow only one setting for all plugins. However, it would also be conceivable to have a separate setting for each plugin, comparable to `filetypes`.

The following test program has been used to verify the pattern
```
#include <iostream>
#include <string>
#include <regex>
 
int main(int argc, char *argv[])
{
  if (argc < 3)
  {
    std::cerr << "usage: " << argv[0] << " pattern filename\n";
    return 1;
  }

  std::string pattern = argv[1];
  std::string file_name = argv[2];

  auto const regex_pattern = std::regex(pattern, 
                                        std::regex_constants::extended |
                                        std::regex_constants::icase);

  auto const match = std::regex_search(file_name, regex_pattern);
  if (match)
    std::cout << file_name << ": skip\n";
  else
    std::cout << file_name << ": keep\n";

  return 0;
}
```

If you run this agains the filename list 
```
Maniac Mansion_Disk1.adf
Maniac Mansion_Disk2.adf
Maniac Mansion_Side A.dsk
Maniac Mansion_Side B.dsk
Maniac Mansion [Side A].d64
Maniac Mansion [Side B].d64
Dragon Ninja [Collection Disk 1].d64
double_dragon_3_(disk_1).stx
double_dragon_3_(disk_2).stx
Bridge Master - Computer Tape A.tzx
Bridge Master - Computer Tape B.tzx
Bored Of The Rings - Side 1.tzx
Bored Of The Rings - Side 2.tzx
Tales of Destiny II (USA) (Disc 1).cue
Tales of Destiny II (USA) (Disc 1) (Track 1).bin
Tales of Destiny II (USA) (Disc 1) (Track 2).bin
Tales of Destiny II (USA) (Disc 2).cue
Tales of Destiny II (USA) (Disc 2) (Track 1).bin
Tales of Destiny II (USA) (Disc 2) (Track 2).bin
Tales of Destiny II (USA) (Disc 3).cue
Tales of Destiny II (USA) (Disc 3) (Track 1).bin
Tales of Destiny II (USA) (Disc 3) (Track 2).bin
```
it will output
```
$ while read -r f;do ./check '((dis[ck]|tape|side|track)[ _-]?[b-z2-9])' "$f"; done <filenames
Maniac Mansion_Disk1.adf: keep
Maniac Mansion_Disk2.adf: skip
Maniac Mansion_Side A.dsk: keep
Maniac Mansion_Side B.dsk: skip
Maniac Mansion [Side A].d64: keep
Maniac Mansion [Side B].d64: skip
Dragon Ninja [Collection Disk 1].d64: keep
double_dragon_3_(disk_1).stx: keep
double_dragon_3_(disk_2).stx: skip
Bridge Master - Computer Tape A.tzx: keep
Bridge Master - Computer Tape B.tzx: skip
Bored Of The Rings - Side 1.tzx: keep
Bored Of The Rings - Side 2.tzx: skip
Tales of Destiny II (USA) (Disc 1).cue: keep
Tales of Destiny II (USA) (Disc 1) (Track 1).bin: keep
Tales of Destiny II (USA) (Disc 1) (Track 2).bin: skip
Tales of Destiny II (USA) (Disc 2).cue: skip
Tales of Destiny II (USA) (Disc 2) (Track 1).bin: skip
Tales of Destiny II (USA) (Disc 2) (Track 2).bin: skip
Tales of Destiny II (USA) (Disc 3).cue: skip
Tales of Destiny II (USA) (Disc 3) (Track 1).bin: skip
Tales of Destiny II (USA) (Disc 3) (Track 2).bin: skip
```
which should roughly correspond to the typical scenario of game collections. If this is not enough, you can adjust the search pattern in `wiiflow_lite.ini`.

For further details on the regex options see [the C++ documentation](https://en.cppreference.com/w/cpp/regex/syntax_option_type).
