### PR TITLE
Show total number of games on filter change

### DIFF
--- a/source/menu/menu.hpp
+++ b/source/menu/menu.hpp
@@ -1061,6 +1061,7 @@ private:
 	//
 	void _showError(void);
 	void _showMain(void);
+	void _showTotalGames(const int numberOfGames);
 	void _showConfigCommon(const TexData & bg, int page);
 	void _showConfig(void);
 	void _showConfig3(void);

--- a/source/menu/menu_main.cpp
+++ b/source/menu/menu_main.cpp
@@ -121,6 +121,13 @@ void CMenu::_showMain()
 		_showCF(m_refreshGameList);
 }
 
+void CMenu::_showTotalGames(const int numberOfGames)
+{
+	m_showtimer = 240;
+	m_btnMgr.setText(m_mainLblNotice, wfmt(_fmt("main7", L"Total Games: %i"), numberOfGames));
+	m_btnMgr.show(m_mainLblNotice);
+}
+
 void CMenu::_showCF(bool refreshList)
 {
 	m_refreshGameList = false;
@@ -345,9 +352,7 @@ void CMenu::_showCF(bool refreshList)
 	if(m_sourceflow || m_current_view == COVERFLOW_HOMEBREW)
 		return;
 
-	m_showtimer = 240;
-	m_btnMgr.setText(m_mainLblNotice, wfmt(_fmt("main7", L"Total Games: %i"), CoverFlow.size()));
-	m_btnMgr.show(m_mainLblNotice);
+	_showTotalGames(CoverFlow.size());
 }
 
 int CMenu::main(void)
@@ -577,6 +582,7 @@ int CMenu::main(void)
 				{
 					m_refreshGameList = false;
 					_initCF();
+					_showTotalGames(CoverFlow.size());
 				}
 			}
 			else if(m_btnMgr.selected(m_mainBtnDVD))
@@ -615,6 +621,7 @@ int CMenu::main(void)
 				m_favorites = !m_favorites;
 				m_cfg.setBool(_domainFromView(), "favorites", m_favorites);
 				_initCF();
+				_showTotalGames(CoverFlow.size());
 			}
 			else if(!CoverFlow.empty() && CoverFlow.select())
 			{
@@ -643,6 +650,7 @@ int CMenu::main(void)
 					{
 						m_refreshGameList = false;
 						_initCF();
+						_showTotalGames(CoverFlow.size());
 					}
 					else
 						CoverFlow.cancel();


### PR DESCRIPTION
This change causes the display of the number of games to reappear whenever it changes by filter (category, favourite).