### PR TITLE
- Ignore USB storage devices without an MBR or WBFS signature

### DIFF
--- a/source/devicemounter/PartitionHandle.cpp
+++ b/source/devicemounter/PartitionHandle.cpp
@@ -151,7 +151,10 @@ bool PartitionHandle::Mount(int pos, const char *name, bool forceFAT)
 		}
 	}
 	if(!valid(pos))
+	{
+		gprintf("No valid partition position found! Failed to mount any partition.\n");
 		return false;
+	}
 
 	SetWbfsHandle(pos, NULL);
 	if(strncmp(GetFSName(pos), "FAT", 3) == 0 || strcmp(GetFSName(pos), "GUID-Entry") == 0)
@@ -195,6 +198,7 @@ bool PartitionHandle::Mount(int pos, const char *name, bool forceFAT)
 		}
 	}
 	/* FAIL */
+	gprintf("Exhausted all supported filesystem types! Failed to mount any partition.\n");
 	MountNameList[pos].clear();
 	return false;
 }


### PR DESCRIPTION
- Ignore USB storage devices without an MBR or WBFS signature (fixes #338, reverts #343) thanks to wiidev/blackb0x for error handling and wbfs check

The original fix for issue #338 breaks support for GPT drives. It was subsequently discovered that the WiiU USB storage drive does not have a protective MBR and that, prior to the original fix, WiiFlow only supported reading from GPT drives with a protective MBR. This updated fix ignores all drives without an MBR signature or a WBFS signature, thereby restoring support for GPT drives with a protective MBR. For more information see [this comment](https://github.com/Fledge68/WiiFlow_Lite/issues/338#issuecomment-1526933068).

This code has been tested with a GPT formatted USB drive, an MBR formatted USB drive, and a WBFS formatted USB drive.