### PR TITLE
Add issue template configuration for GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Bug Report
+about: Create a report of a verified bug to help us improve
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: User Support Forum Thread
+    url: https://gbatemp.net/threads/wiiflow-lite.422685/
+    about: Please ask questions about how to setup or use WiiFlow Lite here


### PR DESCRIPTION
Directs users to the GBAtemp support thread and disables blank issues.

You can try before you buy over at my fork https://github.com/gingerbeardman/WiiFlow_Lite/issues

<img width="1676" height="562" alt="14010" src="https://github.com/user-attachments/assets/7d63ed81-0e27-479a-b4dd-4e6bf83f02a2" />
